### PR TITLE
fix: add missing keywords to package.json

### DIFF
--- a/.changeset/clever-rules-type.md
+++ b/.changeset/clever-rules-type.md
@@ -1,0 +1,5 @@
+---
+"@crescendolab/vite-plugin-version": patch
+---
+
+add missing keywords to package.json

--- a/packages/vite-plugin-version/package.json
+++ b/packages/vite-plugin-version/package.json
@@ -2,6 +2,13 @@
   "name": "@crescendolab/vite-plugin-version",
   "version": "0.0.3",
   "description": "A Vite plugin to inject version information into the build",
+  "keywords": [
+    "vite",
+    "plugin",
+    "version",
+    "build",
+    "inject"
+  ],
   "homepage": "https://github.com/crescendolab-open/vite-plugin-version",
   "repository": {
     "type": "git",


### PR DESCRIPTION


# Copilot

This pull request includes a patch update to the `@crescendolab/vite-plugin-version` package, adding missing keywords to its `package.json` file for better discoverability.

Metadata improvements:

* [`.changeset/clever-rules-type.md`](diffhunk://#diff-679798669264e1e604af73babb5885c85132064c3dc4f26041849645a713071dR1-R5): Added a changeset describing the patch update for the `@crescendolab/vite-plugin-version` package.
* [`packages/vite-plugin-version/package.json`](diffhunk://#diff-4a6876e982d26d1ba4bd14f57b6673cc711e0bba204e89ee0275f6ecfca80a0fR5-R11): Added the `keywords` field with relevant terms (`vite`, `plugin`, `version`, `build`, `inject`) to enhance package discoverability.