### PR TITLE
fix: update version labels in demo HTML for clarity

### DIFF
--- a/packages/demo/index.html
+++ b/packages/demo/index.html
@@ -19,7 +19,7 @@
         ></code
       >
     </h1>
-    <div>Runtime Version: <span id="version">Loading...</span></div>
-    <div>File Version: <span id="file-version">Loading...</span></div>
+    <div>Virtual Module Version: <span id="version">Loading...</span></div>
+    <div>Static File Version: <span id="file-version">Loading...</span></div>
   </body>
 </html>


### PR DESCRIPTION


# Copilot

This pull request includes a small change to the `packages/demo/index.html` file. The change updates the labels for version information displayed on the page to clarify their context. Specifically, "Runtime Version" was changed to "Virtual Module Version," and "File Version" was changed to "Static File Version."